### PR TITLE
added   getBlocks

### DIFF
--- a/dist/nxt-api.js
+++ b/dist/nxt-api.js
@@ -6056,6 +6056,10 @@ var Nxt;
         API.prototype.getBlock = function (req, callback) {
             return this._call('getBlock', req, callback);
         };
+        
+        API.prototype.getBlocks = function (req, callback) {
+            return this._call('getBlocks', req, callback);
+        };
 
         API.prototype.getBlockId = function (req, callback) {
             return this._call('getBlockId', req, callback);


### PR DESCRIPTION
Documented api call getBocks was missing, this spec from /tests on 1.3.5
